### PR TITLE
Fix redundant alias in new Java versions

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -137,7 +137,9 @@ then
 
 	add_alias_check $JENV_ALIAS
 	add_alias_check $JAVA_VERSION
-	add_alias_check $JAVA_SHORTVERSION
+	if [ "$JAVA_SHORTVERSION" != "$JAVA_VERSION" ]; then
+		add_alias_check $JAVA_SHORTVERSION
+	fi
 
 
 	if $version_added ; then


### PR DESCRIPTION
It seems that newer versions of Java go away from the 1.X.X version format.  Perhaps a new version parser is needed but this fixes a current issue where JAVA_SHORTVERSION and JAVA_VERSION are equal and jenv tries to add the version alias twice.