### PR TITLE
Fix shell version when invoked from a script

### DIFF
--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -22,7 +22,11 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(basename "$SHELL")"
+  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
+  shell="${shell%% *}"
+  shell="${shell##-}"
+  shell="${shell:-$SHELL}"
+  shell="${shell##*/}"
 fi
 
 resolve_link() {


### PR DESCRIPTION
When invoked from a shell script, `$(jenv init -)` did not get theshell name correct.
These code is get from rbenv.